### PR TITLE
Keep images in use

### DIFF
--- a/openstack_images_sync/sync/mirror.py
+++ b/openstack_images_sync/sync/mirror.py
@@ -1,0 +1,64 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import novaclient.client as novaclient
+import novaclient.v2.client as novaclient_v2
+import simplestreams.mirrors.glance as sstream_glance
+import simplestreams.openstack as sstream_openstack
+import simplestreams.util as sstream_util
+
+from openstack_images_sync.core import logging
+
+
+class OISGlanceMirror(sstream_glance.GlanceMirror):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.logger = logging.get_logger()
+
+        client = kwargs.get("client")
+
+        if client is None:
+            client = sstream_openstack
+        self.keystone_creds = client.load_keystone_creds()
+        service_info = sstream_openstack.get_service_conn_info(
+            service="compute", **self.keystone_creds
+        )
+        self.nova_client: novaclient_v2.Client = novaclient.Client(
+            "2.1", session=service_info["session"]
+        )
+
+    def remove_item(self, data, src, target, pedigree):
+        """Remove an item from the target.
+
+        If the item is in use, it will not be removed.
+        """
+        if "id" not in data:
+            sstream_util.products_del(target, pedigree)
+            return
+        servers = self.nova_client.servers.list(
+            search_opts={"all_tenants": 1, "image": data["id"]}
+        )
+        nb_servers = len(servers)
+        if nb_servers > 0:
+            self.logger.warning(
+                "Not removing %s: %s. In use by %d server(s)",
+                data["id"],
+                data["name"],
+                nb_servers,
+            )
+            return
+
+        sstream_util.products_del(target, pedigree)
+        self.logger.info("Removing %s: %s", data["id"], data["name"])
+        self.gclient.images.delete(data["id"])

--- a/openstack_images_sync/sync/synchronize.py
+++ b/openstack_images_sync/sync/synchronize.py
@@ -23,6 +23,7 @@ import simplestreams.objectstores as sstream_objectstores
 import simplestreams.util as sstream_util
 
 from openstack_images_sync.core import config, logging
+from openstack_images_sync.sync import mirror as sync_mirror
 
 KEYRING = "/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg"
 
@@ -149,7 +150,7 @@ class SimpleStreamsSynchronizer:
                     "Fetched images to sync: %s",
                     ", ".join(drmirror.items.keys()) or "no images to sync",
                 )
-                tmirror = sstream_glance.GlanceMirror(
+                tmirror = sync_mirror.OISGlanceMirror(
                     config=mirror_config,
                     objectstore=tstore,
                     region=region,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "python-simplestreams",
     "python-keystoneclient",
     "python-glanceclient",
+    "python-novaclient",
     "click",
 ]
 


### PR DESCRIPTION
Deleting images currently from glance is dangerous as it will make life harder during rebuild / live migration of virtual machines.

On each item scheduled for removal, pre-emptively check if any virtual machine is using the image. Delete the image neither from the product catalog nor glance if it is the case.

Example of logs with removal prevented:
```
2024-04-10 21:41:36 openstack-image-sync.run:88 INFO Starting simplestreams synchronizer.
2024-04-10 21:41:36 openstack-image-sync.sync_mirrors:144 INFO Fetching images to sync for region: RegionOne from http://cloud-images.ubuntu.com/releases
2024-04-10 21:41:38 openstack-image-sync.sync_mirrors:149 INFO Fetched images to sync: no images to sync
2024-04-10 21:41:39 openstack-image-sync.sync_mirrors:160 INFO Syncing region: RegionOne from http://cloud-images.ubuntu.com/releases
2024-04-10 21:41:41 openstack-image-sync.remove_item:59 INFO Removing 890e07eb-d2f1-4cb2-b0d8-0f2735ccca86: auto-sync/ubuntu-jammy-22.04-amd64-server-20240221-disk1.img
2024-04-10 21:41:41 openstack-image-sync.remove_item:59 INFO Removing 2c5f6608-cce4-4f62-b593-4de8b1e54dcb: auto-sync/ubuntu-jammy-22.04-amd64-server-20240223-disk1.img
2024-04-10 21:41:43 openstack-image-sync.remove_item:50 WARNING Not removing 9ce5b6f1-c6f2-47a8-8b70-af549ffa85bd: auto-sync/ubuntu-jammy-22.04-amd64-server-20240301-disk1.img. In use by 1 server(s)
2024-04-10 21:41:43 openstack-image-sync.remove_item:59 INFO Removing 9e7fa2b9-6cb1-4abb-a51c-1afc409076ee: auto-sync/ubuntu-jammy-22.04-amd64-server-20240308-disk1.img
2024-04-10 21:41:44 openstack-image-sync.remove_item:59 INFO Removing 63b3de0a-b648-4112-891d-4e297f85170e: auto-sync/ubuntu-jammy-22.04-arm64-server-20240221-disk1.img
2024-04-10 21:41:45 openstack-image-sync.remove_item:59 INFO Removing fe69ad19-5fc3-4218-8e7b-fefc497c2cfb: auto-sync/ubuntu-jammy-22.04-arm64-server-20240223-disk1.img
2024-04-10 21:41:46 openstack-image-sync.remove_item:59 INFO Removing 39b830b0-7b98-4ac4-a1dd-78ace148059e: auto-sync/ubuntu-jammy-22.04-arm64-server-20240301-disk1.img
2024-04-10 21:41:47 openstack-image-sync.remove_item:59 INFO Removing cdd24759-b9d3-4614-8149-c5341a2b6b03: auto-sync/ubuntu-jammy-22.04-arm64-server-20240308-disk1.img
2024-04-10 21:41:48 openstack-image-sync.sync_mirrors:162 INFO Synced region: RegionOne from http://cloud-images.ubuntu.com/releases
2024-04-10 21:41:48 openstack-image-sync.run:105 INFO Next synchronization: 2024-04-10 22:41:48.768789
```